### PR TITLE
Update install_with_git.yml

### DIFF
--- a/tasks/install_with_git.yml
+++ b/tasks/install_with_git.yml
@@ -8,7 +8,7 @@
 - name: Get group for user {{ linuxbrew_user }}
   command: id -g
   register: linuxbrew_user_group
-  become: "{{ linuxbrew_user }}"
+  become_user: "{{ linuxbrew_user }}"
   changed_when: false
 
 - name: Set Linuxbrew group


### PR DESCRIPTION
Using the `become: "{linuxbrew_user}"` fails because `become` expects a boolean value. We should use `become_user` to impersonate another user.